### PR TITLE
MySQL TIMESTAMP fields are unquoted

### DIFF
--- a/hm-backup.php
+++ b/hm-backup.php
@@ -1494,7 +1494,7 @@ class HM_Backup {
 	    	$field_set[$j] = $this->sql_backquote( mysql_field_name( $result, $j ) );
 	    	$type = mysql_field_type( $result, $j );
 
-	    	if ( $type === 'tinyint' || $type === 'smallint' || $type === 'mediumint' || $type === 'int' || $type === 'bigint'  || $type === 'timestamp')
+	    	if ( $type === 'tinyint' || $type === 'smallint' || $type === 'mediumint' || $type === 'int' || $type === 'bigint' )
 	    		$field_num[$j] = true;
 
 	    	else


### PR DESCRIPTION
Which creates an invalid database dump.
