### PR TITLE
Adds a RecursiveFilterIterator

### DIFF
--- a/hm-backup.php
+++ b/hm-backup.php
@@ -1651,8 +1651,8 @@ class ExcludesFilterIterator extends RecursiveFilterIterator {
 
 	public function accept() {
 
-		$excludes = array( '.git', '.svn', '.idea' );
-		return ! ( $this->isDir() && in_array( $this->getFilename(), $excludes ) );
+		$excludes = array( '.git', '.svn', '.DS_Store' );
+		return ! ( in_array( $this->getFilename(), $excludes ) );
 
 	}
 


### PR DESCRIPTION
Fixes an issue where the Iterator would fatal error on .git folders. Version control and IDE folders aren't desirable anyway. So this ignores them from the filesystem scanner

We would need to also hide these from display on the BackUpWordPress admin page.

Fixes https://github.com/humanmade/backupwordpress/issues/592 for me
